### PR TITLE
Fix double call to this.toggle(), 

### DIFF
--- a/index.js
+++ b/index.js
@@ -13,7 +13,7 @@ var MaterialSwitch = React.createClass({
   getDefaultProps() {
     return {
       active: false,
-      style: {},
+      styles: {},
       inactiveButtonColor: '#2196F3',
       inactiveButtonPressedColor: '#42A5F5',
       activeButtonColor: '#FAFAFA',
@@ -190,14 +190,17 @@ var MaterialSwitch = React.createClass({
     var doublePadding = this.padding*2-2;
     var halfPadding = doublePadding/2;
     return (
-      <View style={[{padding: this.padding, position: 'relative'}, this.props.style]}>
-        <View style={{
+      <View
+        {...this._panResponder.panHandlers}
+        style={{padding: this.padding, position: 'relative'}}>
+        <View
+          style={{
             backgroundColor: this.state.state ? this.props.activeBackgroundColor : this.props.inactiveBackgroundColor,
             height: this.props.switchHeight,
             width: this.props.switchWidth,
             borderRadius: this.props.switchHeight/2,
           }}/>
-        <TouchableHighlight underlayColor='transparent' activeOpacity={1} onPress={() => { this.toggle(); }} style={{
+        <TouchableHighlight underlayColor='transparent' activeOpacity={1} style={{
             height: Math.max(this.props.buttonRadius*2+doublePadding, this.props.switchHeight+doublePadding),
             width: this.props.switchWidth+doublePadding,
             position: 'absolute',
@@ -221,7 +224,6 @@ var MaterialSwitch = React.createClass({
               transform: [{ translateX: this.state.position }]
             },
             this.props.buttonShadow]}
-            {...this._panResponder.panHandlers}
           >
             {this.props.buttonContent}
           </Animated.View>

--- a/index.js
+++ b/index.js
@@ -13,7 +13,7 @@ var MaterialSwitch = React.createClass({
   getDefaultProps() {
     return {
       active: false,
-      styles: {},
+      style: {},
       inactiveButtonColor: '#2196F3',
       inactiveButtonPressedColor: '#42A5F5',
       activeButtonColor: '#FAFAFA',


### PR DESCRIPTION
When the circle in the switch is pressed. 

TouchHighlight and onPanResponderRelease both make the call the `this.toggle()` which i'll toggle the state twice. 

I simply removed the this.toggle() from TouchHighLight and move `{...this._panResponder.panHandlers}` to it's parent view.

Thanks