### PR TITLE
Disable component when enableSlide is set to false

### DIFF
--- a/index.js
+++ b/index.js
@@ -57,6 +57,8 @@ var MaterialSwitch = React.createClass({
       onMoveShouldSetPanResponderCapture: (evt, gestureState) => true,
 
       onPanResponderGrant: (evt, gestureState) => {
+        if (!this.props.enableSlide) return;
+
         this.setState({pressed: true});
         this.start.x0 = gestureState.x0;
         this.start.pos = this.state.position._value;
@@ -179,6 +181,8 @@ var MaterialSwitch = React.createClass({
   },
 
   toggle() {
+    if (!this.props.enableSlide) return;
+
     if (this.state.state) {
       this.deactivate();
     } else {

--- a/index.js
+++ b/index.js
@@ -1,11 +1,12 @@
-var React = require('react-native');
+var React = require('react');
+var ReactNative = require('react-native');
 
 var {
   PanResponder,
   View,
   TouchableHighlight,
   Animated,
-} = React;
+} = ReactNative;
 
 var MaterialSwitch = React.createClass({
   padding: 2,


### PR DESCRIPTION
When I set enableSlide to false, I was expecting the control to be disabled, but it didn't work.

I prevent the component to become a responder and prevent the toggle function to be executed if enableSlide is set to false.
Seems to me like a more natural behaviour.