### PR TITLE
Apply the style prop

### DIFF
--- a/index.js
+++ b/index.js
@@ -197,7 +197,7 @@ var MaterialSwitch = React.createClass({
     return (
       <View
         {...this._panResponder.panHandlers}
-        style={{padding: this.padding, position: 'relative'}}>
+        style={[{padding: this.padding, position: 'relative'}, this.props.style]}>
         <View
           style={{
             backgroundColor: this.state.state ? this.props.activeBackgroundColor : this.props.inactiveBackgroundColor,


### PR DESCRIPTION
The README states that you can supply a `style` prop to the `Switch` in order to specify margins and such.  However, the `style` prop was being ignored.

This PR applies the `style` prop to the outer container view as documented.
