### PR TITLE
Feature/buttonOffset

### DIFF
--- a/index.js
+++ b/index.js
@@ -145,7 +145,7 @@ var MaterialSwitch = React.createClass({
     Animated.timing(
       this.state.position,
       {
-        toValue: (this.state.width - this.props.buttonOffset),
+        toValue: this.state.width,
         duration: this.props.switchAnimationTime,
       }
     ).start();

--- a/index.js
+++ b/index.js
@@ -143,7 +143,7 @@ var MaterialSwitch = React.createClass({
     Animated.timing(
       this.state.position,
       {
-        toValue: this.state.width,
+        toValue: this.state.width -5,
         duration: this.props.switchAnimationTime,
       }
     ).start();
@@ -154,7 +154,7 @@ var MaterialSwitch = React.createClass({
     Animated.timing(
       this.state.position,
       {
-        toValue: 0,
+        toValue: 5,
         duration: this.props.switchAnimationTime,
       }
     ).start();

--- a/index.js
+++ b/index.js
@@ -31,6 +31,7 @@ var MaterialSwitch = React.createClass({
       switchWidth: 40,
       switchHeight: 20,
       buttonContent: null,
+      buttonOffset: 0,
       enableSlide: true,
       switchAnimationTime: 200,
       onActivate: function() {},
@@ -40,11 +41,12 @@ var MaterialSwitch = React.createClass({
   },
 
   getInitialState() {
-    var w = this.props.switchWidth - Math.min(this.props.switchHeight, this.props.buttonRadius*2);
+    var w = (this.props.switchWidth - Math.min(this.props.switchHeight, this.props.buttonRadius*2) - this.props.buttonOffset);
+
     return {
       width: w,
       state: this.props.active,
-      position: new Animated.Value(this.props.active? w : 0),
+      position: new Animated.Value(this.props.active? w : this.props.buttonOffset),
     };
   },
 
@@ -143,7 +145,7 @@ var MaterialSwitch = React.createClass({
     Animated.timing(
       this.state.position,
       {
-        toValue: this.state.width -5,
+        toValue: (this.state.width - this.props.buttonOffset),
         duration: this.props.switchAnimationTime,
       }
     ).start();
@@ -154,7 +156,7 @@ var MaterialSwitch = React.createClass({
     Animated.timing(
       this.state.position,
       {
-        toValue: 5,
+        toValue: this.props.buttonOffset,
         duration: this.props.switchAnimationTime,
       }
     ).start();


### PR DESCRIPTION
This PR adds the prop to be able to set a `buttonOffset`. This would allow the icon inside the switch to remain offset within the button by a configurable amount of pixels. 

It allows one the possibility of: 

<img width="372" alt="screen shot 2017-05-03 at 9 37 41 am" src="https://cloud.githubusercontent.com/assets/1131641/25671310/5adfa046-2fe4-11e7-9de3-c0b93cc5d75a.png">

As well as: 

<img width="372" alt="screen shot 2017-05-03 at 9 37 53 am" src="https://cloud.githubusercontent.com/assets/1131641/25671318/650db0d0-2fe4-11e7-8847-7104ea9658a0.png">

The switches above are not currently possible without this PR as the inner white button always hugs the far ends of the switch otherwise.

The prop defaults to zero, so there is no effect if the prop is not used, the switch will function normally as always.

Thanks for the lib!

