### PR TITLE
Added property 'enableSlideDragging'

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ var Application = React.createClass({
 * `switchHeight` (Number) - (default: 20),
 * `buttonContent` (React.Component) - Custom inline content for switch button (default: null),
 * `enableSlide` (Boolean) - (default: true),
+* `enableSlideDragging` - (default: true) - Allows to change the position of the toggle by sliding. Does not work in react-native-web. If disabled, you can only toggle by pressing,
 * `switchAnimationTime` (Number) - Switch animation duration (default: 200),
 
 ### Events

--- a/index.js
+++ b/index.js
@@ -28,6 +28,7 @@ var MaterialSwitch = createReactClass({
     switchHeight: PropTypes.number,
     buttonContent: PropTypes.element,
     enableSlide: PropTypes.bool,
+    enableSlideDragging: PropTypes.bool,
     switchAnimationTime: PropTypes.number,
     onActivate: PropTypes.func,
     onDeactivate: PropTypes.func,
@@ -57,6 +58,7 @@ var MaterialSwitch = createReactClass({
       buttonContent: null,
       buttonOffset: 0,
       enableSlide: true,
+      enableSlideDragging: true,
       switchAnimationTime: 200,
       onActivate: function() {},
       onDeactivate: function() {},
@@ -228,9 +230,13 @@ var MaterialSwitch = createReactClass({
   render() {
     var doublePadding = this.padding*2-2;
     var halfPadding = doublePadding/2;
+
+    let panHandlers = this.props.enableSlideDragging ? this._panResponder.panHandlers : null
+    let pressHandlers = !this.props.enableSlideDragging ? { onPress: () => this.toggle() } : null
+
     return (
       <View
-        {...this._panResponder.panHandlers}
+        {...panHandlers}
         style={[{padding: this.padding, position: 'relative'}, this.props.style]}>
         <View
           style={{
@@ -239,7 +245,7 @@ var MaterialSwitch = createReactClass({
             width: this.props.switchWidth,
             borderRadius: this.props.switchHeight/2,
           }}/>
-        <TouchableHighlight underlayColor='transparent' activeOpacity={1} style={{
+        <TouchableHighlight {...pressHandlers} underlayColor='transparent' activeOpacity={1} style={{
             height: Math.max(this.props.buttonRadius*2+doublePadding, this.props.switchHeight+doublePadding),
             width: this.props.switchWidth+doublePadding,
             position: 'absolute',


### PR DESCRIPTION
`prop.enableSlideDragging` determines whether you toggle by sliding or pressing on the switch.

When `enableSlideDragging` is `false` this component can be used in web (via react-native-web)